### PR TITLE
Redhat support

### DIFF
--- a/lib/vagrant-bindfs/cap/redhat/bindfs_install.rb
+++ b/lib/vagrant-bindfs/cap/redhat/bindfs_install.rb
@@ -6,11 +6,14 @@ module VagrantPlugins
 
           def self.bindfs_install(machine)
             machine.communicate.tap do |comm|
+
+              require "vagrant-bindfs/version"
+
               if comm.test("grep \"CentOS release 6\" /etc/centos-release")
                 comm.sudo("yum -y install fuse fuse-devel")
                 comm.sudo("wget http://bindfs.org/downloads/bindfs-#{VagrantPlugins::Bindfs::SOURCE_VERSION}.tar.gz -O bindfs.tar.gz")
                 comm.sudo("tar --overwrite -zxvf bindfs.tar.gz")
-                comm.sudo("[ -d ./bindfs ] && cd bindfs && ./configure && make && make install")
+                comm.sudo("[ -d ./bindfs-#{VagrantPlugins::Bindfs::SOURCE_VERSION} ] && cd bindfs-#{VagrantPlugins::Bindfs::SOURCE_VERSION} && ./configure && make && make install")
                 comm.sudo("ln -s /usr/local/bin/bindfs /usr/bin")
               else
                 comm.sudo("yum -y install bindfs")

--- a/lib/vagrant-bindfs/cap/redhat/bindfs_install.rb
+++ b/lib/vagrant-bindfs/cap/redhat/bindfs_install.rb
@@ -6,14 +6,14 @@ module VagrantPlugins
 
           def self.bindfs_install(machine)
             machine.communicate.tap do |comm|
-              if comm.test('grep "CentOS release 6" /etc/centos-release')
-                comm.sudo('yum -y install fuse fuse-devel')
-                comm.sudo('wget http://bindfs.org/downloads/bindfs-#{VagrantPlugins::Bindfs::SOURCE_VERSION}.tar.gz -O bindfs.tar.gz')
-                comm.sudo('tar --overwrite -zxvf bindfs.tar.gz')
-                comm.sudo('[ -d ./bindfs ] && cd bindfs && ./configure && make && make install')
-                comm.sudo('ln -s /usr/local/bin/bindfs /usr/bin')
+              if comm.test("grep \"CentOS release 6\" /etc/centos-release")
+                comm.sudo("yum -y install fuse fuse-devel")
+                comm.sudo("wget http://bindfs.org/downloads/bindfs-#{VagrantPlugins::Bindfs::SOURCE_VERSION}.tar.gz -O bindfs.tar.gz")
+                comm.sudo("tar --overwrite -zxvf bindfs.tar.gz")
+                comm.sudo("[ -d ./bindfs ] && cd bindfs && ./configure && make && make install")
+                comm.sudo("ln -s /usr/local/bin/bindfs /usr/bin")
               else
-                comm.sudo('yum -y install bindfs')
+                comm.sudo("yum -y install bindfs")
               end
             end
           end


### PR DESCRIPTION
I changed to use double quotes so we could use string substitution, added a require for version.rb and fixed the expected bindfs directory path by adding the version number.
